### PR TITLE
Fix OoR Error

### DIFF
--- a/visuals/canvasAnimation.js
+++ b/visuals/canvasAnimation.js
@@ -150,11 +150,15 @@ class CanvasSimulation {
         const infection = actor.myInfection;
         // If they're not symptomatic yet, find out what % they are in the "daysToSymptomatic"
         if (!actor.isSymptomatic) {
-            return COLOR_SPECTRUM.EXPOSED[Math.floor((infection.infectedTime / infection.daysToSymptomatic) * 20)];
+            let colorIndex = Math.floor((infection.infectedTime / infection.daysToSymptomatic) * 20);
+            if (colorIndex >= COLOR_SPECTRUM.EXPOSED.length) { colorIndex = COLOR_SPECTRUM.EXPOSED.length - 1; }
+            return COLOR_SPECTRUM.EXPOSED[colorIndex];
         }
-        // If they're symptomatic, 
+        // If they're symptomatic, find how long they've been in the symptomatic range as %.
         if (actor.isSymptomatic) {
-            return COLOR_SPECTRUM.INFECTIOUS[Math.floor(((infection.infectedTime - infection.daysToSymptomatic) / infection.durationDaysOfAntigenDetection) * 20)];
+            let colorIndex = Math.floor(((infection.infectedTime - infection.daysToSymptomatic) / infection.durationDaysOfAntigenDetection) * 20);
+            if (colorIndex >= COLOR_SPECTRUM.INFECTIOUS.length) { colorIndex = COLOR_SPECTRUM.INFECTIOUS.length - 1; }
+            return COLOR_SPECTRUM.INFECTIOUS[colorIndex];
         }
 
         // Fallback? Should we ever get here?


### PR DESCRIPTION
Fixes an out of range error if the calculated period surpasses the length of the spectrum (% is based on 20 as the interval, may need to be adjusted). If exceeds the length of the pre-defined color spectrum, will lock at the last color until the actor's status changes.

This issue was manifesting itself as colored balls disappearing, while the grey "shield" was still rendered.

## Screenshot

<img width="1054" alt="COVID_Rapid-test_Simulation" src="https://user-images.githubusercontent.com/1711639/106227715-8e983980-619e-11eb-8dfd-4772a973ddf4.png">
